### PR TITLE
feat(auth): add forgot and reset password functionality with email notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ app.*.map.json
 android/key.properties
 android/app/my-release-key.jks
 android/app/key.jks
+
+# Server related
+/server/.env
+/server/.env.local
+/server/.env.development.local
+/server/node_modules

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,1 +1,3 @@
 .env
+
+node_modules

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -95,6 +95,19 @@ userSchema.methods.comparePassword = async function (candidatePassword) {
     return await bcrypt.compare(candidatePassword, this.password);
 };
 
+// Instance method to generate password reset token
+userSchema.methods.generatePasswordResetToken = async function () {
+    const rawToken = Math.floor(Math.random() * 1000000).toString().padStart(6, '0');
+    const salt = await bcrypt.genSalt(parseInt(process.env.BCRYPT_ROUNDS) || 12);
+    this.passwordResetToken = await bcrypt.hash(rawToken, salt);
+    this.passwordResetExpires = Date.now() + 3600000; // 1 hour
+    return rawToken; // Return the raw token for sending in email
+};
+
+userSchema.methods.comparePasswordResetToken = async function (token) {
+    return await bcrypt.compare(token, this.passwordResetToken);
+}
+
 // Instance method to handle failed login attempts
 userSchema.methods.incLoginAttempts = function () {
     // Clear attempts if lock has expired

--- a/server/node_modules/.bin/mime
+++ b/server/node_modules/.bin/mime
@@ -1,1 +1,16 @@
-../mime/cli.js
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../mime/cli.js" "$@"
+else 
+  exec node  "$basedir/../mime/cli.js" "$@"
+fi

--- a/server/node_modules/.bin/mkdirp
+++ b/server/node_modules/.bin/mkdirp
@@ -1,1 +1,16 @@
-../mkdirp/bin/cmd.js
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../mkdirp/bin/cmd.js" "$@"
+else 
+  exec node  "$basedir/../mkdirp/bin/cmd.js" "$@"
+fi

--- a/server/node_modules/.bin/nodemon
+++ b/server/node_modules/.bin/nodemon
@@ -1,1 +1,16 @@
-../nodemon/bin/nodemon.js
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../nodemon/bin/nodemon.js" "$@"
+else 
+  exec node  "$basedir/../nodemon/bin/nodemon.js" "$@"
+fi

--- a/server/node_modules/.bin/nodetouch
+++ b/server/node_modules/.bin/nodetouch
@@ -1,1 +1,16 @@
-../touch/bin/nodetouch.js
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../touch/bin/nodetouch.js" "$@"
+else 
+  exec node  "$basedir/../touch/bin/nodetouch.js" "$@"
+fi

--- a/server/node_modules/.bin/semver
+++ b/server/node_modules/.bin/semver
@@ -1,1 +1,16 @@
-../semver/bin/semver.js
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        if command -v cygpath > /dev/null 2>&1; then
+            basedir=`cygpath -w "$basedir"`
+        fi
+    ;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  exec "$basedir/node"  "$basedir/../semver/bin/semver.js" "$@"
+else 
+  exec node  "$basedir/../semver/bin/semver.js" "$@"
+fi

--- a/server/node_modules/.package-lock.json
+++ b/server/node_modules/.package-lock.json
@@ -1303,6 +1303,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,7 +20,8 @@
         "mongoose": "^7.5.0",
         "morgan": "^1.10.0",
         "multer": "^2.0.1",
-        "multer-storage-cloudinary": "^4.0.0"
+        "multer-storage-cloudinary": "^4.0.0",
+        "nodemailer": "^7.0.5"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -1322,6 +1323,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "mongoose": "^7.5.0",
     "morgan": "^1.10.0",
     "multer": "^2.0.1",
-    "multer-storage-cloudinary": "^4.0.0"
+    "multer-storage-cloudinary": "^4.0.0",
+    "nodemailer": "^7.0.5"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -5,7 +5,9 @@ const {
     register,
     login,
     logout,
-    getCurrentUser
+    getCurrentUser,
+    forgotPassword,
+    resetPassword
 } = require('../controllers/auth');
 
 const router = express.Router();
@@ -13,6 +15,10 @@ const router = express.Router();
 // Routes
 router.post('/register', upload.single('profileImage'), register);
 router.post('/login', login);
+
+router.post('/forgot-password', forgotPassword);
+router.post('/reset-password', resetPassword);
+
 router.post('/logout', authMiddleware, logout);
 router.get('/me', authMiddleware, getCurrentUser);
 

--- a/server/services/email.service.js
+++ b/server/services/email.service.js
@@ -1,0 +1,46 @@
+const nodemailer = require('nodemailer');
+const fs = require('fs');
+
+// Email service configuration
+const transporter = nodemailer.createTransport({
+    host: process.env.EMAIL_HOST,
+    port: process.env.EMAIL_PORT,
+    secure: process.env.EMAIL_SECURE === 'true', // true for 465, false for other ports
+    auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+    }
+});
+
+
+async function sendEmail({ to, subject, userName, token, url }) {
+    try {
+        if (!to || !subject) {
+            throw new Error('To and subject are required for sending an email');
+        }
+        const mailOptions = {
+            from: `"Brevity" <${process.env.EMAIL_USER}>`,
+            to,
+            subject,
+        };
+        if(!token && !url) {
+            let fullHtml = fs.readFileSync('services/templates/reset-successful.html', 'utf8');
+            fullHtml = fullHtml.replace('{{userName}}', userName);
+            mailOptions.html = fullHtml;
+        }
+        if (token) {
+            let fullHtml = fs.readFileSync('services/templates/reset-password.html', 'utf8');
+            fullHtml = fullHtml.replace('{{userName}}', userName);
+            fullHtml = fullHtml.replace('{{token}}', token);
+            mailOptions.html = fullHtml;
+        }
+        await transporter.sendMail(mailOptions);
+        console.log('Email sent successfully');
+    } catch (error) {
+        console.error('Error sending email:', error);
+    }
+}
+
+module.exports = {
+    sendEmail
+};

--- a/server/services/templates/reset-password.html
+++ b/server/services/templates/reset-password.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset</title>
+</head>
+<body>
+    <h1>Password Reset</h1>
+    <p>Hi {{userName}},</p>
+    <p>We received a request to reset your password. Enter the code below:</p>
+    <h2>{{token}}</h2>
+    <p>The code is valid for next 1 hour. If you did not request this, please ignore this email.</p>
+    <p>Thank you!</p>
+</body>
+<footer>
+    <p>&copy; Brevity. All rights reserved.</p>
+</footer>
+</html>

--- a/server/services/templates/reset-successful.html
+++ b/server/services/templates/reset-successful.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Successfully Reset</title>
+</head>
+<body>
+    <h1>Password Changed Successfully</h1>
+    <p>Hi {{userName}},</p>
+    <p>Your password has been successfully updated. If you made this change, no further action is required.</p>
+    <p>If you did <strong>not</strong> request this change, please contact our support team immediately or reset your password again to secure your account.</p>
+    <p>Thank you for using Brevity!</p>
+</body>
+<footer>
+    <p>&copy; Brevity. All rights reserved.</p>
+</footer>
+</html>


### PR DESCRIPTION
## [CHANGELOG]

- Implemented forgotPassword and resetPassword methods in auth controller.
- Added email service for sending password reset emails using nodemailer.
- Created HTML templates for password reset and successful reset notifications.
- Updated user model to generate and validate password reset tokens.
- Enhanced user registration flow to check for email verification instead of account activation.
- Updated routes to include new password management endpoints.
- Added nodemailer dependency for email handling.

### [ADDITIONAL INFORMATION]

Add the following to `./server/.env`

```
EMAIL_HOST=smtp.gmail.com
EMAIL_PORT=587
EMAIL_SECURE=false
EMAIL_USER="your_email_id"
EMAIL_PASS="your_app_password"