### PR TITLE
feat(auth): implement email verification process with token generation and resend functionality

### DIFF
--- a/server/helper/html.helper.js
+++ b/server/helper/html.helper.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const html = (username) => {
+    const filePath = path.join(__dirname, '..', 'public', 'email-verification-successful.html');
+    let htmlContent = fs.readFileSync(filePath, 'utf-8');
+    htmlContent = htmlContent.replace('{{userName}}', username);
+    return htmlContent;
+}
+
+module.exports = {
+    html
+};

--- a/server/helper/jwt.helper.js
+++ b/server/helper/jwt.helper.js
@@ -1,0 +1,29 @@
+const jwt = require('jsonwebtoken');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const encode = (payload) => {
+    try {
+        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRE });
+        return token;
+    } catch (error) {
+        console.error('Error encoding JWT:', error);
+        return null;
+    }
+};
+
+const decode = (token) => {
+    try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+        return decoded;
+    } catch (error) {
+        console.error('Error decoding JWT:', error);
+        return null;
+    }
+};
+
+module.exports = {
+    encode,
+    decode
+};

--- a/server/helper/jwt.helper.js
+++ b/server/helper/jwt.helper.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 const encode = (payload) => {
     try {
-        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRE });
+        const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
         return token;
     } catch (error) {
         console.error('Error encoding JWT:', error);

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,9 @@ const rateLimit = require('express-rate-limit');
 const authRoutes = require('./routes/auth');
 const userRoutes = require('./routes/user');
 
+// Import controllers
+const { verifyEmail } = require('./controllers/auth');
+
 // Import middleware
 const { errorHandler } = require('./middleware/error');
 
@@ -59,6 +62,9 @@ app.get('/api/health', (req, res) => {
         timestamp: new Date().toISOString()
     });
 });
+
+// Email verification route
+app.get('/auth/verify-email', verifyEmail);
 
 // Error handling middleware (must be last)
 app.use(errorHandler);

--- a/server/public/email-verification-successful.html
+++ b/server/public/email-verification-successful.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Email Verified - Brevity</title>
+  <style>
+    :root {
+      --primary-bg: #0d1b2a;
+      --secondary-bg: #1b263b;
+      --accent: #4CAF50;
+      --text-color: #e0e1dd;
+      --heading-color: #f5f5f5;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background-color: var(--primary-bg);
+      color: var(--text-color);
+      line-height: 1.6;
+      padding: 2rem;
+    }
+
+    .container {
+      max-width: 600px;
+      margin: auto;
+      background-color: var(--secondary-bg);
+      border-radius: 10px;
+      padding: 3rem 2rem;
+      box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+      text-align: center;
+    }
+
+    h1 {
+      color: var(--accent);
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
+
+    p {
+      font-size: 1.1rem;
+      color: var(--text-color);
+      margin-bottom: 1rem;
+    }
+
+    .checkmark {
+      font-size: 3rem;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+
+    .footer {
+      margin-top: 2rem;
+      font-size: 0.9rem;
+      color: #888;
+    }
+
+    @media (max-width: 600px) {
+      body {
+        padding: 1rem;
+      }
+      .container {
+        padding: 2rem 1.5rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="checkmark">✓</div>
+    <h1>Email Verified</h1>
+    <p>Hi {{userName}}, your email has been successfully verified.</p>
+    <p>You can now continue using Brevity without any interruptions.</p>
+    <div class="footer">&copy; Brevity. All rights reserved.</div>
+  </div>
+</body>
+</html>

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -7,13 +7,15 @@ const {
     logout,
     getCurrentUser,
     forgotPassword,
-    resetPassword
+    resetPassword,
+    resendVerification
 } = require('../controllers/auth');
 
 const router = express.Router();
 
 // Routes
 router.post('/register', upload.single('profileImage'), register);
+router.post('/resend-verification', resendVerification);
 router.post('/login', login);
 
 router.post('/forgot-password', forgotPassword);

--- a/server/services/email.service.js
+++ b/server/services/email.service.js
@@ -23,7 +23,7 @@ async function sendEmail({ to, subject, userName, token, url }) {
             to,
             subject,
         };
-        if(!token && !url) {
+        if (!token && !url) {
             let fullHtml = fs.readFileSync('services/templates/reset-successful.html', 'utf8');
             fullHtml = fullHtml.replace('{{userName}}', userName);
             mailOptions.html = fullHtml;
@@ -34,8 +34,15 @@ async function sendEmail({ to, subject, userName, token, url }) {
             fullHtml = fullHtml.replace('{{token}}', token);
             mailOptions.html = fullHtml;
         }
+        if (url) {
+            const _url = `${process.env.DEPLOYMENT_URL}/auth/verify-email?token=${url}`;
+            const safeUrl = _url.replace(/&/g, '&amp;');
+            let fullHtml = fs.readFileSync('services/templates/email-verification.html', 'utf8');
+            fullHtml = fullHtml.replace('{{userName}}', userName);
+            fullHtml = fullHtml.replace('{{verificationLink}}', safeUrl);
+            mailOptions.html = fullHtml;
+        }
         await transporter.sendMail(mailOptions);
-        console.log('Email sent successfully');
     } catch (error) {
         console.error('Error sending email:', error);
     }

--- a/server/services/templates/email-verification.html
+++ b/server/services/templates/email-verification.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Email Verification</title>
+</head>
+
+<body>
+    <h1>Email Verification</h1>
+    <p>Hi {{userName}},</p>  
+    <p>Welcome to Brevity! Please click the button below to verify your email address:</p>
+    <a href="{{verificationLink}}"
+        style="display: inline-block; background-color: #4CAF50; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px;"
+        target="_blank">
+        Verify Email
+    </a>
+
+    <p>The link is valid for next 1 hour.</p>
+    <p>Thank you!</p>
+</body>
+<footer>
+    <p>&copy; Brevity. All rights reserved.</p>
+</footer>
+
+</html>


### PR DESCRIPTION
## [CHANGELOG]

- Implemented a link-based email verification system.
- At time of registration, an email is sent to the user with a link, clicking which will redirect the user to a browser page, confirming that the email was verified.
- A link is valid for the duration of 1 hour, if the user does not verify in the duration, then the user can request another by posting on `/resend-verification` endpoint.

## [ADDITIONAL INFORMATION]
### .env
```
# Server
PORT=5001
NODE_ENV=development

# Database
MONGODB_URI="mongodb_url"

# JWT Configuration
JWT_SECRET="secret"
JWT_REFRESH_SECRET="refresh_secret"
JWT_EXPIRE=7d
JWT_REFRESH_EXPIRE=30d

# Cloudinary (Media Uploads)
CLOUDINARY_CLOUD_NAME=your_cloudinary_name
CLOUDINARY_API_KEY=your_cloudinary_api_key
CLOUDINARY_API_SECRET=your_cloudinary_api_secret

# Security
BCRYPT_ROUNDS=12
MAX_LOGIN_ATTEMPTS=5
LOCK_TIME=30

# Email Configuration
EMAIL_HOST=smtp.gmail.com
EMAIL_PORT=587
EMAIL_SECURE=false
EMAIL_USER="email_address"
EMAIL_PASS="app_password"

# DEPLOYMENT URL
DEPLOYMENT_URL="localhost:5001" # Change this to your actual deployment URL
```

## [FIXED]

Issue #81