### PR TITLE
Fix: Chatbot delete functionality #91

### DIFF
--- a/lib/views/inner_screens/chat_screen.dart
+++ b/lib/views/inner_screens/chat_screen.dart
@@ -393,7 +393,34 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
               ),
             ),
           );
+        } else if (state is ChatInitial) { // <--- ADDED FIX: Explicitly handle ChatInitial state
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.chat_bubble_outline,
+                  color: theme.primaryColor.withAlpha((0.5 * 255).toInt()),
+                  size: 60,
+                ),
+                Gap(20),
+                Text(
+                  'Start a conversation about the article!',
+                  style: TextStyle(color: Colors.white70, fontSize: 16),
+                  textAlign: TextAlign.center,
+                ),
+                Gap(10),
+                Text(
+                  'Your chat history will appear here.',
+                  style: TextStyle(color: Colors.white54, fontSize: 12),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          );
         }
+        // This 'return' should only catch truly unexpected states,
+        // or a genuine loading state if introduced separately from ChatInitial.
         return Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Closes #91

This PR fixes the bug where the chatbot's delete button would continuously show "initialization" and a loading spinner, and new messages could not be sent after clearing the chat.

**Problem Analysis:**
The issue stemmed from two main points:
1.  **UI State Handling:** The `ChatScreen`'s `BlocConsumer` in `_buildMessageList` did not explicitly handle the `ChatInitial` state. When `ClearChat` was dispatched and `ChatInitial()` was emitted by the BLoC, the UI fell back to its default loading/initializing display.
2.  **Message Sending Block:** The `_onSendMessage` method in `ChatBloc` had a guard clause (`if (state is! ChatLoaded) return;`) that prevented sending messages when the state was `ChatInitial`, effectively blocking new conversations after a clear.

**Solution:**
1.  **`lib/views/inner_screens/chat_screen.dart`**: Added an `else if (state is ChatInitial)` block within the `_buildMessageList` widget's `builder`. This now explicitly displays a "Start a conversation about the article!" message, hiding the spinner, when the chat is empty.
2.  **`lib/controller/bloc/chat_bloc/chat_bloc.dart`**: Modified the `_onClearChat` method to emit `ChatLoaded` (with an empty list of conversations) instead of `ChatInitial`. This ensures that after clearing, the BLoC is in a state (`ChatLoaded`) that allows new messages to be sent immediately.

These changes ensure the delete functionality works as intended, clearing the conversation and allowing seamless new interactions.


https://github.com/user-attachments/assets/2ca49434-661e-4c24-93e3-ec6fbb66cb94

