### PR TITLE
Fix: Password field obscured by default and eye icon logic #110

### DIFF
--- a/lib/views/auth/login.dart
+++ b/lib/views/auth/login.dart
@@ -267,9 +267,10 @@ class _LoginScreenState extends State<LoginScreen>
                         delay: 400,
                         suffixIcon: IconButton(
                           icon: Icon(
-                            _obscurePassword
-                                ? Icons.visibility
-                                : Icons.visibility_off,
+                            // FLIP THE LOGIC HERE:
+                            _obscurePassword // If _obscurePassword is true (password is hidden)
+                                ? Icons.visibility_off // Show a CLOSED eye (meaning "click to reveal")
+                                : Icons.visibility, // Else (password is visible), show an OPEN eye (meaning "click to hide")
                             color: Colors.white54,
                           ),
                           onPressed: () {

--- a/lib/views/auth/signup.dart
+++ b/lib/views/auth/signup.dart
@@ -343,8 +343,8 @@ class _SignupScreenState extends State<SignupScreen>
                         suffixIcon: IconButton(
                           icon: Icon(
                             _obscurePassword
-                                ? Icons.visibility
-                                : Icons.visibility_off,
+                                ? Icons.visibility_off
+                                : Icons.visibility,
                             color: Colors.white54,
                           ),
                           onPressed: () {


### PR DESCRIPTION
Closes #110

**Problem:**
On the signup screen, the password input field exhibited an inverted logic for its visibility toggle. The "eye" icon was displayed in an open state (suggesting the password was visible) when the characters were actually hidden. Conversely, when the "eye" icon was in a closed/crossed-out state, the password characters became visible. This behavior was counter-intuitive to standard user expectations for password fields.

**Analysis:**
The `_obscurePassword` boolean state variable correctly controlled whether the `TextFormField` obscured the characters (`true` for hidden, `false` for visible). However, the `IconButton` used as the `suffixIcon` was configured to display `Icons.visibility` (open eye) when `_obscurePassword` was `true`, and `Icons.visibility_off` (closed eye) when `_obscurePassword` was `false`. This directly reversed the common visual metaphor for password visibility toggles.

**Solution:**
The fix involved adjusting the icon selection logic within the `suffixIcon` `IconButton` of the password `AnimatedTextFormField` in `lib/views/auth/signup.dart`.

The icon selection logic was flipped to align with standard UI/UX patterns:
* When `_obscurePassword` is `true` (meaning the password characters are **hidden**), the icon is now `Icons.visibility_off` (a **closed eye**). This visually indicates that the password is currently hidden and can be revealed by clicking the icon.
* When `_obscurePassword` is `false` (meaning the password characters are **visible**), the icon is now `Icons.visibility` (an **open eye**). This visually indicates that the password is currently visible and can be hidden by clicking the icon.

This ensures that the visual state of the eye icon correctly reflects the actual visibility of the password characters and matches user expectations.

**Before:**
https://github.com/user-attachments/assets/ef9cc44c-dcb8-4324-a18a-b3e58af1dd6f

**After:**
https://github.com/user-attachments/assets/2af4442c-0b3e-4ba4-b5bc-dd11b00e52fe




