### PR TITLE
fix: adapt text color to theme brightness

### DIFF
--- a/lib/views/common_widgets/common_appbar.dart
+++ b/lib/views/common_widgets/common_appbar.dart
@@ -51,10 +51,14 @@ class ParticlesHeader extends StatelessWidget {
                   child ??
                   Text(
                     title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontFamily: 'Roboto',
                       letterSpacing: 1.2,
-                      color: Color.fromARGB(255, 223, 223, 223),
+                      // Darker text in light mode; light text in dark mode
+                      color:
+                          Theme.of(context).brightness == Brightness.light
+                              ? Colors.black87
+                              : const Color.fromARGB(255, 223, 223, 223),
                       fontWeight: FontWeight.bold,
                       fontSize: 23,
                     ),


### PR DESCRIPTION
Issue #181

## Before
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-17 at 09 05 17" src="https://github.com/user-attachments/assets/e18dc200-43c1-4588-a385-d503fbc34d33" />

## After
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-08-17 at 09 02 56" src="https://github.com/user-attachments/assets/0ed34f3b-a017-4721-a01a-4dd1604e2e2b" />
