### PR TITLE
Implement account deletion

### DIFF
--- a/lib/controller/services/backend_service.dart
+++ b/lib/controller/services/backend_service.dart
@@ -31,7 +31,7 @@ class ApiService {
   /// Initialize tokens from storage
   Future<void> initializeTokens() async {
     final prefs = await SharedPreferences.getInstance();
-    _accessToken = prefs.getString('access_token');
+    _accessToken = prefs.getString('accessToken'); // Changed from 'access_token' to match AuthService
     _refreshToken = prefs.getString('refresh_token');
   }
 
@@ -41,7 +41,7 @@ class ApiService {
     _refreshToken = refreshToken;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('access_token', accessToken);
+    await prefs.setString('accessToken', accessToken); // Changed from 'access_token' to match AuthService
     await prefs.setString('refresh_token', refreshToken);
   }
 
@@ -51,7 +51,7 @@ class ApiService {
     _refreshToken = null;
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('access_token');
+    await prefs.remove('accessToken'); // Changed from 'access_token' to match AuthService
     await prefs.remove('refresh_token');
   }
 

--- a/lib/controller/services/firestore_service.dart
+++ b/lib/controller/services/firestore_service.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 
 import 'package:brevity/models/user_model.dart';
+import 'package:brevity/utils/api_config.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';
 
 class UserRepository {
-  final String _baseUrl = 'https://brevity-backend-khaki.vercel.app/api/users';
+  String get _baseUrl => ApiConfig.usersUrl;
   String? _accessToken;
 
   // Singleton pattern
@@ -24,7 +25,7 @@ class UserRepository {
   Future<UserModel> getUserProfile(String uid) async {
     try {
       final response = await http.get(
-        Uri.parse('https://brevity-backend-khaki.vercel.app/api/auth/me'),
+        Uri.parse('${ApiConfig.authUrl}/me'),
         headers: {
           'Authorization': 'Bearer $_accessToken',
           'Content-Type': 'application/json',
@@ -235,6 +236,35 @@ class UserRepository {
       }
     } catch (e) {
       throw Exception('Failed to remove profile image: $e');
+    }
+  }
+
+  // Delete user account
+  Future<void> deleteUserAccount({String? password, String? googleIdToken}) async {
+    try {
+      final body = <String, dynamic>{};
+      if (password != null) {
+        body['password'] = password;
+      }
+      if (googleIdToken != null) {
+        body['googleIdToken'] = googleIdToken;
+      }
+
+      final response = await http.delete(
+        Uri.parse('$_baseUrl/deleteAccount'),
+        headers: {
+          'Authorization': 'Bearer $_accessToken',
+          'Content-Type': 'application/json',
+        },
+        body: json.encode(body),
+      );
+
+      if (response.statusCode != 200) {
+        final errorData = json.decode(response.body);
+        throw Exception(errorData['message'] ?? 'Failed to delete account');
+      }
+    } catch (e) {
+      throw Exception('Failed to delete account: $e');
     }
   }
 

--- a/lib/controller/services/reaction_service.dart
+++ b/lib/controller/services/reaction_service.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:brevity/models/article_model.dart';
+import 'package:brevity/controller/services/backend_service.dart' as backend;
+import 'package:brevity/controller/services/auth_service.dart' as auth;
+import 'package:brevity/utils/logger.dart';
+import 'package:http/http.dart' as http;
+
+class _ReactionRequest {
+  final Article article;
+  final String action; // 'like', 'dislike', 'remove_like', 'remove_dislike'
+
+  _ReactionRequest(this.article, this.action);
+}
+
+/// Queue that serializes reaction API calls (one at a time).
+class ReactionQueue {
+  static final ReactionQueue _instance = ReactionQueue._internal();
+  factory ReactionQueue() => _instance;
+  ReactionQueue._internal();
+
+  final List<_ReactionRequest> _queue = [];
+  bool _processing = false;
+
+  // Map article.url -> backend articleId (returned when article is created on first like/dislike)
+  final Map<String, String> _articleIdMap = {};
+  // Track which URLs are liked/disliked (populated from server on preload)
+  final Set<String> _likedUrls = {};
+  final Set<String> _dislikedUrls = {};
+  bool _loaded = false;
+
+  void enqueueLike(Article article) {
+    _enqueue(_ReactionRequest(article, 'like'));
+  }
+
+  void enqueueDislike(Article article) {
+    _enqueue(_ReactionRequest(article, 'dislike'));
+  }
+
+  void enqueueRemoveLike(Article article) {
+    _enqueue(_ReactionRequest(article, 'remove_like'));
+  }
+
+  void enqueueRemoveDislike(Article article) {
+    _enqueue(_ReactionRequest(article, 'remove_dislike'));
+  }
+
+  void _enqueue(_ReactionRequest req) {
+    _queue.add(req);
+    if (!_processing) {
+      _processNext();
+    }
+  }
+
+  Future<void> _processNext() async {
+    if (_queue.isEmpty) {
+      _processing = false;
+      return;
+    }
+
+    _processing = true;
+    final req = _queue.removeAt(0);
+
+    try {
+      switch (req.action) {
+        case 'like':
+          await _sendLike(req.article);
+          break;
+        case 'dislike':
+          await _sendDislike(req.article);
+          break;
+        case 'remove_like':
+          await _sendRemoveLike(req.article);
+          break;
+        case 'remove_dislike':
+          await _sendRemoveDislike(req.article);
+          break;
+        default:
+          Log.w('Unknown reaction action: ${req.action}');
+      }
+    } catch (e, st) {
+      Log.e('Reaction request failed: $e\n$st');
+      // Swallow errors to keep UI smooth per requirements
+    }
+
+    // Process next in queue
+    // Slight delay to avoid hammering server when user rapidly toggles
+    await Future.delayed(const Duration(milliseconds: 80));
+    _processNext();
+  }
+
+  Map<String, String> _buildHeaders() {
+    final headers = <String, String>{'Content-Type': 'application/json'};
+  // Prefer token from AuthService since app stores it there; fallback to ApiService
+  final token = auth.AuthService().accessToken ?? backend.ApiService().accessToken;
+    if (token != null) headers['Authorization'] = 'Bearer $token';
+    return headers;
+  }
+
+  Future<void> _sendLike(Article article) async {
+  final uri = Uri.parse('${backend.ApiService.baseUrl}/reactions/like');
+    final body = article.toJson();
+
+  final resp = await http.post(uri, headers: _buildHeaders(), body: jsonEncode(body)).timeout(const Duration(seconds: 30));
+    if (resp.statusCode == 200) {
+      try {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        final articleId = decoded['data']?['articleId']?.toString();
+        if (articleId != null) {
+          _articleIdMap[article.url] = articleId;
+        }
+  // Update local sets so UI can reflect persisted state
+  _likedUrls.add(article.url);
+  _dislikedUrls.remove(article.url);
+      } catch (e) {
+        // ignore malformed response
+      }
+    } else {
+      Log.w('Like API returned ${resp.statusCode}');
+    }
+  }
+
+  Future<void> _sendDislike(Article article) async {
+  final uri = Uri.parse('${backend.ApiService.baseUrl}/reactions/dislike');
+    final body = article.toJson();
+
+    final resp = await http.post(uri, headers: _buildHeaders(), body: jsonEncode(body)).timeout(const Duration(seconds: 30));
+    if (resp.statusCode == 200) {
+      try {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        final articleId = decoded['data']?['articleId']?.toString();
+        if (articleId != null) {
+          _articleIdMap[article.url] = articleId;
+        }
+  _dislikedUrls.add(article.url);
+  _likedUrls.remove(article.url);
+      } catch (e) {
+        // ignore malformed response
+      }
+    } else {
+      Log.w('Dislike API returned ${resp.statusCode}');
+    }
+  }
+
+  Future<void> _sendRemoveLike(Article article) async {
+    final articleId = _articleIdMap[article.url];
+    if (articleId == null) {
+      return;
+    }
+
+  final uri = Uri.parse('${backend.ApiService.baseUrl}/reactions/like/$articleId');
+    final resp = await http.delete(uri, headers: _buildHeaders()).timeout(const Duration(seconds: 30));
+    if (resp.statusCode == 200) {
+      // Optionally remove mapping
+  _articleIdMap.remove(article.url);
+  _likedUrls.remove(article.url);
+    } else {
+      Log.w('Remove like API returned ${resp.statusCode}');
+    }
+  }
+
+  Future<void> _sendRemoveDislike(Article article) async {
+    final articleId = _articleIdMap[article.url];
+    if (articleId == null) return;
+
+  final uri = Uri.parse('${backend.ApiService.baseUrl}/reactions/dislike/$articleId');
+    final resp = await http.delete(uri, headers: _buildHeaders()).timeout(const Duration(seconds: 30));
+    if (resp.statusCode == 200) {
+      _articleIdMap.remove(article.url);
+      _dislikedUrls.remove(article.url);
+    } else {
+      Log.w('Remove dislike API returned ${resp.statusCode}');
+    }
+  }
+
+  /// Fetch reacted news from backend and populate local liked/disliked sets.
+  Future<void> preloadReactions() async {
+    if (_loaded) return;
+    _loaded = true;
+    try {
+      final uri = Uri.parse('${backend.ApiService.baseUrl}/reactions/reacted-news');
+      final resp = await http.get(uri, headers: _buildHeaders()).timeout(const Duration(seconds: 20));
+      if (resp.statusCode == 200) {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        final data = decoded['data'] as Map<String, dynamic>?;
+        final reactions = data?['reactions'] as List<dynamic>?;
+        if (reactions != null) {
+          for (final r in reactions) {
+            try {
+              final item = r as Map<String, dynamic>;
+              final url = item['url']?.toString();
+                  final articleId = item['articleId']?.toString();
+              final type = item['reactionType']?.toString();
+              if (url == null || type == null) continue;
+                  if (articleId != null) {
+                    _articleIdMap[url] = articleId;
+                  }
+              if (type == 'like') {
+                _likedUrls.add(url);
+                _dislikedUrls.remove(url);
+              } else if (type == 'dislike') {
+                _dislikedUrls.add(url);
+                _likedUrls.remove(url);
+              }
+            } catch (e) {
+              // ignore malformed reaction entry
+            }
+          }
+        }
+      } else {
+        Log.w('Preload reacted-news returned ${resp.statusCode}');
+      }
+    } catch (e, st) {
+      Log.e('Failed to preload reactions: $e\n$st');
+    }
+  }
+
+  bool isArticleLiked(String url) => _likedUrls.contains(url);
+  bool isArticleDisliked(String url) => _dislikedUrls.contains(url);
+}

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -260,6 +260,7 @@ userSchema.methods.getReactedNews = async function() {
     const likedNews = this.reactions.likes
         .filter(like => like.articleId) // Filter out any null references
         .map(like => ({
+            articleId: like.articleId._id ? like.articleId._id.toString() : undefined,
             headline: like.articleId.title,
             source: like.articleId.sourceName,
             description: like.articleId.description,
@@ -272,6 +273,7 @@ userSchema.methods.getReactedNews = async function() {
     const dislikedNews = this.reactions.dislikes
         .filter(dislike => dislike.articleId) // Filter out any null references
         .map(dislike => ({
+            articleId: dislike.articleId._id ? dislike.articleId._id.toString() : undefined,
             headline: dislike.articleId.title,
             source: dislike.articleId.sourceName, 
             description: dislike.articleId.description,


### PR DESCRIPTION
# 📌 Pull Request

## 📝 Description
Implemented the **Account Deletion feature**.  
Users can now delete their accounts securely via the Settings screen.  
Supports both normal login (password-based) and OAuth (Google) users.

Closes #256

## 🔄 Changes Made
- Added `deleteAccount()` method to **AuthService**
- Added password confirmation dialog for normal login users
- Integrated backend `DELETE /api/users/deleteAccount` endpoint
- Updated **Settings screen**:
  - Changed label from “Delete Profile” → “Delete Account”
  - Added confirmation dialog with password input field
  - Added error/success handling with SnackBars
- Updated **UserRepository** for consistency with account deletion
- Added `deleteAccount()` method in **UserProfileCubit** to clear local profile state
- Fixed **token storage key mismatch** (`accessToken` vs `access_token`) across services

## ✅ Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have added/updated tests where necessary  
- [x] I have attached required proof (logs + screenshots of deletion flow)  
- [x] No new warnings or errors are introduced  
- [x] I have reviewed my code before requesting review  

## ⚠️ Known Limitations / Next Steps
- Google OAuth login is **not yet fully implemented** — sign-in buttons are placeholders, so OAuth account deletion is handled only if the server identifies the account correctly.  
- Future improvement: Implement `signInWithGoogle()` in `AuthService` and wire Google login/signup buttons to actual functionality.  
